### PR TITLE
Add tqdm to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sphinxcontrib-bibtex
 nbsphinx
 nbstripout
 numpydoc
+tqdm


### PR DESCRIPTION
Hi there 👋!

I was looking at the notebooks you made to use them for a short demo during a talk about making collaborating between scientists easier. One of the notebooks raised an error because tqdm wasn't installed so this PR adds that.

Testing this now.